### PR TITLE
Fix finding resource for logback file

### DIFF
--- a/logback-configuration-core/src/main/java/org/carlspring/logging/services/impl/LoggingManagementServiceImpl.java
+++ b/logback-configuration-core/src/main/java/org/carlspring/logging/services/impl/LoggingManagementServiceImpl.java
@@ -16,18 +16,19 @@ import org.springframework.stereotype.Service;
 
 import java.io.*;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import static org.carlspring.logging.utils.LogBackXmlConfiguration.resolveLogbackConfigurationFile;
 import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 
 /**
  * @author mtodorov
  * @author Yougeshwar
+ * @author Pablo Tirado
  */
 @Service
 public class LoggingManagementServiceImpl
@@ -224,29 +225,6 @@ public class LoggingManagementServiceImpl
             close(is);
             close(fos);
         }
-    }
-
-    private File resolveLogbackConfigurationFile(String path) throws URISyntaxException, FileNotFoundException
-    {
-        File file;
-        URL url = LoggingManagementServiceImpl.class.getClassLoader().getResource(path);
-        if (url != null)
-        {
-            logger.debug("Resolved the Logback configuration class from the classpath (" + url.toURI() + ").");
-
-            file = new File(url.toURI());
-        }
-        else
-        {
-            file = new File(path);
-            if (!file.exists())
-            {
-                throw new FileNotFoundException("Failed to locate the Logback configuration file!");
-            }
-
-            logger.debug("Resolved the Logback configuration class from the file system (" + file.getAbsolutePath() + ").");
-        }
-        return file;
     }
 
     @Override

--- a/logback-configuration-core/src/main/java/org/carlspring/logging/utils/LogBackXmlConfiguration.java
+++ b/logback-configuration-core/src/main/java/org/carlspring/logging/utils/LogBackXmlConfiguration.java
@@ -1,28 +1,32 @@
 package org.carlspring.logging.utils;
 
-import java.io.File;
-import java.net.URL;
-import java.util.List;
+import org.carlspring.logging.*;
+import org.carlspring.logging.exceptions.AppenderNotFoundException;
+import org.carlspring.logging.exceptions.LoggerNotFoundException;
+import org.carlspring.logging.exceptions.LoggingConfigurationException;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 
-import org.carlspring.logging.Appender;
-import org.carlspring.logging.AppenderRef;
-import org.carlspring.logging.Configuration;
-import org.carlspring.logging.Logger;
-import org.carlspring.logging.ObjectFactory;
-import org.carlspring.logging.exceptions.AppenderNotFoundException;
-import org.carlspring.logging.exceptions.LoggerNotFoundException;
-import org.carlspring.logging.exceptions.LoggingConfigurationException;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Yougeshwar
+ * @author Pablo Tirado
  */
 public class LogBackXmlConfiguration
 {
+
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(LogBackXmlConfiguration.class);
     
     private String pathToXml;
     
@@ -183,8 +187,7 @@ public class LogBackXmlConfiguration
     {
         try
         {
-            URL url = LogBackXmlConfiguration.class.getClassLoader().getResource(pathToXml);
-            File file = new File(url.toURI());
+            File file = resolveLogbackConfigurationFile(this.pathToXml);
 
             JAXBContext jaxbContext = JAXBContext.newInstance(Configuration.class);
             Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
@@ -208,8 +211,7 @@ public class LogBackXmlConfiguration
     {
         try
         {
-            URL url = LogBackXmlConfiguration.class.getClassLoader().getResource(pathToXml);
-            File file = new File(url.toURI());
+            File file = resolveLogbackConfigurationFile(this.pathToXml);
 
             JAXBContext jaxbContext = JAXBContext.newInstance(Configuration.class);
 
@@ -222,5 +224,29 @@ public class LogBackXmlConfiguration
         {
             throw new LoggingConfigurationException(ex);
         }
+    }
+
+    public static File resolveLogbackConfigurationFile(String pathToXml)
+            throws URISyntaxException, FileNotFoundException
+    {
+        Path path;
+        URL url = LogBackXmlConfiguration.class.getClassLoader().getResource(pathToXml);
+        if (url != null)
+        {
+            LOGGER.debug("Resolved the Logback configuration class from the classpath ({}).", url.toURI());
+
+            path = Paths.get(url.toURI());
+        }
+        else
+        {
+            path = Paths.get(pathToXml);
+            if (!path.toFile().exists())
+            {
+                throw new FileNotFoundException("Failed to locate the Logback configuration file!");
+            }
+
+            LOGGER.debug("Resolved the Logback configuration class from the file system ({}).", path.toAbsolutePath());
+        }
+        return path.toFile();
     }
 }

--- a/logback-configuration-core/src/main/java/org/carlspring/logging/utils/LogBackXmlConfiguration.java
+++ b/logback-configuration-core/src/main/java/org/carlspring/logging/utils/LogBackXmlConfiguration.java
@@ -26,16 +26,14 @@ import org.slf4j.LoggerFactory;
 public class LogBackXmlConfiguration
 {
 
-    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(LogBackXmlConfiguration.class);
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(LogBackXmlConfiguration.class);
     
     private String pathToXml;
     
     public LogBackXmlConfiguration(String pathToXml)
     {
         this.pathToXml = pathToXml;
-        this.pathToXml = pathToXml != null ? 
-                    pathToXml :
-                    "logback.xml";
+        this.pathToXml = pathToXml != null ? pathToXml : "logback.xml";
     }
 
     public void addLogger(String packageName, String levelName, String appenderName)
@@ -233,7 +231,7 @@ public class LogBackXmlConfiguration
         URL url = LogBackXmlConfiguration.class.getClassLoader().getResource(pathToXml);
         if (url != null)
         {
-            LOGGER.debug("Resolved the Logback configuration class from the classpath ({}).", url.toURI());
+            logger.debug("Resolved the Logback configuration class from the classpath ({}).", url.toURI());
 
             path = Paths.get(url.toURI());
         }
@@ -245,8 +243,10 @@ public class LogBackXmlConfiguration
                 throw new FileNotFoundException("Failed to locate the Logback configuration file!");
             }
 
-            LOGGER.debug("Resolved the Logback configuration class from the file system ({}).", path.toAbsolutePath());
+            logger.debug("Resolved the Logback configuration class from the file system ({}).", path.toAbsolutePath());
         }
+        
         return path.toFile();
     }
+    
 }


### PR DESCRIPTION
Related issue: [#512](https://github.com/strongbox/strongbox/issues/512)

The test created for LoggingManagementController were returning a 400 code with this exception;
`org.carlspring.logging.exceptions.LoggingConfigurationException: org.carlspring.logging.exceptions.LoggingConfigurationException: java.lang.NullPointerException`

Looking at the code, the problem is in the project logback-configuration:

   ```
 public Configuration unmarshalLogbackXML() throws LoggingConfigurationException {
        try {
            URL url = LogBackXmlConfiguration.class.getClassLoader().getResource(this.pathToXml); // this returns null. The path to XML exists, but not in the classpath
            File file = new File(url.toURI()); // url is null, so there's a NullPointerException
            [...]
    }
```
The proposal is this:

   ```
 public Configuration unmarshalLogbackXML() throws LoggingConfigurationException {
        try {
            File file = resolveLogbackConfigurationFile(this.pathToXml);
            [...]
    }
```


This method has been used:

  ```
  public static File resolveLogbackConfigurationFile(String pathToXml)
            throws URISyntaxException, FileNotFoundException
    {
        Path path;
        URL url = LogBackXmlConfiguration.class.getClassLoader().getResource(pathToXml);
        if (url != null)
        {
            LOGGER.debug("Resolved the Logback configuration class from the classpath ({}).", url.toURI());

            path = Paths.get(url.toURI());
        }
        else
        {
            path = Paths.get(pathToXml);
            if (!path.toFile().exists())
            {
                throw new FileNotFoundException("Failed to locate the Logback configuration file!");
            }

            LOGGER.debug("Resolved the Logback configuration class from the file system ({}).", path.toAbsolutePath());
        }
        return path.toFile();
    }
```